### PR TITLE
Move setup so tests can complete when offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,21 @@ for order in query:
     order.Employee = empl
     Service.save(order)
 ```
+
+## Running tests
+
+To run the tests, you can use pytest or unittest:
+
+- python -m pytest
+- python -m unittest discover
+
+To include tests that call the Northwind service, set the envionment variable:
+
+```
+export ODATA_DO_REMOTE_TESTS=1
+```
+
+The Northwind tests are automatically skipped if it cannot connect to the service.
+
+Test dependency:
+- responses

--- a/odata/tests/test_nw_manual_model.py
+++ b/odata/tests/test_nw_manual_model.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import os
 
 from odata.service import ODataService
+from odata.exceptions import ODataConnectionError
 from odata.entity import declarative_base
 from odata.property import StringProperty, IntegerProperty
 
@@ -41,8 +43,17 @@ class Product(Base):
     quantity_per_unit = StringProperty('QuantityPerUnit')
 
 
-@unittest.skip('unavailable')
+@unittest.skipUnless(os.environ.get('ODATA_DO_REMOTE_TESTS', False),
+        'Avoid Northwind service unless requested')
 class NorthwindManualModelReadTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            # Test query to make sure we have an OData connection
+            q = service.query(Customer).first()
+        except ODataConnectionError:
+            raise unittest.SkipTest('Unable to connect to Northwind service')
 
     def test_query_one(self):
         q = service.query(Customer)

--- a/odata/tests/test_nw_reflect_model.py
+++ b/odata/tests/test_nw_reflect_model.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import os
 
 from odata.service import ODataService
 from odata.exceptions import ODataConnectionError
@@ -10,8 +11,8 @@ Service = None
 Customer = None
 Product = None
 
-
-@unittest.skip('unavailable')
+@unittest.skipUnless(os.environ.get('ODATA_DO_REMOTE_TESTS', False),
+        'Avoid Northwind service unless requested')
 class NorthwindReflectModelReadTest(unittest.TestCase):
 
     @classmethod

--- a/odata/tests/test_nw_reflect_model.py
+++ b/odata/tests/test_nw_reflect_model.py
@@ -3,16 +3,27 @@
 import unittest
 
 from odata.service import ODataService
+from odata.exceptions import ODataConnectionError
 
 
-url = 'http://services.odata.org/V4/Northwind/Northwind.svc/'
-Service = ODataService(url, reflect_entities=True)
-Customer = Service.entities.get('Customers')
-Product = Service.entities.get('Products')
+Service = None
+Customer = None
+Product = None
 
 
 @unittest.skip('unavailable')
 class NorthwindReflectModelReadTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        global Service, Customer, Product
+        url = 'http://services.odata.org/V4/Northwind/Northwind.svc/'
+        try:
+            Service = ODataService(url, reflect_entities=True)
+        except ODataConnectionError:
+            raise unittest.SkipTest('Unable to connect to Northwind service')
+        Customer = Service.entities.get('Customers')
+        Product = Service.entities.get('Products')
 
     def test_query_one(self):
         q = Service.query(Customer)


### PR DESCRIPTION
Although the tests for the Northwind service are skipped, the setup of the service is not. This means it tries to reflect entities (by downloading the $metadata document). This means the test fails even though it should have been skipped.

This PR moves the setup of the service into the test class doing the setup unless you are running the tests. I  added an environment variable to run the normally skipped tests and documented running the tests in the readme.